### PR TITLE
Edits to the "GitHub way" guide

### DIFF
--- a/pages/contribute/github_way.md
+++ b/pages/contribute/github_way.md
@@ -21,7 +21,7 @@ The steps to be followed by contributors are detailed below.
 2. Click on "Issues" in the top menu bar and check existing issues to see if your idea or suggestion is already being addressed.
   * If yes, add your comments to the existing issue.
   * If not, create a new issue by clicking on the green "New issue" on the right.
-3. Choose one of the issues template and create a new issue [ preview here ](https://docs.github.com/en/github/managing-your-work-on-github/creating-an-issue).
+3. Choose one of the issues template and create a new issue [preview here](https://docs.github.com/en/github/managing-your-work-on-github/creating-an-issue).
   * Report a bug.
   * Edit or Fix existing text or image.
   * Add a new topic as a new page.

--- a/pages/contribute/github_way.md
+++ b/pages/contribute/github_way.md
@@ -21,20 +21,22 @@ The steps to be followed by contributors are detailed below.
 2. Click on "Issues" in the top menu bar and check existing issues to see if your idea or suggestion is already being addressed.
   * If yes, add your comments to the existing issue.
   * If not, create a new issue by clicking on the green "New issue" on the right.
-3. Choose one of the issues template and [create a new issue](https://docs.github.com/en/github/managing-your-work-on-github/creating-an-issue).
-  * Correct a typo, fix a link or report a bug.
-  * Edit existing text or image, or add new paragraphs to existing pages.
+3. Choose one of the issues template and create a new issue [ preview here ](https://docs.github.com/en/github/managing-your-work-on-github/creating-an-issue).
+  * Report a bug.
+  * Edit or Fix existing text or image.
   * Add a new topic as a new page.
-4. Discuss your idea with the editors through comments in the issues. You will receive be notified when others comment your issues. Read the comments and Write your opinion/questions/answers on "Leave a comment" box and click on the green "comment" button on the right.
+  * General Discussion.
+4. Discuss your idea with the editors through comments in the issues. You will be notified when others comment on your issues. Read the comments and write your opinion/questions/answers on "Leave a comment" box and click on the green "comment" button on the right.
 
 ### Write your content
-1. When you and the editors agree on the type of contribution, you can go to the page you want to edit on the website and click on "Edit me" pencil icon, shown next to the page title. If a new page need to be created, the editors will provide you the link to the page through issues comments.
-2. In the GitHub repository, click on the pencil icon, shown on the right. 
-3. You can now edit or add new text and images according to the provided template. GitHub provide a guide for [writing and formatting in GitHub](https://docs.github.com/en/github/writing-on-github/getting-started-with-writing-and-formatting-on-github). We also provide a [demo](https://elixir-europe.github.io/rdm-toolkit/demo_page.html) to show you how to write in this webpage. Make sure to read our style guide before start writing.
+1. When you and the editors have agreed on the type of contribution, you can go to the page you want to edit on the website and click on "Edit me" pencil icon, shown next to the page title. OR if you were looking to add new content and require a new page,the editors will provide you the link to the page via comments in the issue you created. The page will come with a predefined template based on the kind of content you want to contribute. 
+2. The "Edit me" pencil icon will take you to the GitHub repository where you again click on the pencil icon, shown on the right and start editing. 
+3. You can now edit or add new text and images according to the provided template. GitHub provide a guide for writing and formatting in GitHub [preview here](https://docs.github.com/en/github/writing-on-github/getting-started-with-writing-and-formatting-on-github). We also provide a [demo](https://elixir-europe.github.io/rdm-toolkit/demo_page.html) to show you how to write in this webpage. Make sure to read our style guide before start writing.
 4. When you are happy with your content, go to the “Propose changes” section at the end of the page and write a title and a brief explanation about your changes.
 5. Click on “Propose changes”. 
-6. You are now redirected on the Pull Request (PR) page. By clicking on the Pull Request green button you can choose to
+6. You are now redirected on the Pull Request (PR) page. By clicking on the Create Pull Request green button you are redirected to Open Pull Request page and from there you can choose to
   * open a "[Draft Pull Request](https://docs.github.com/en/github/collaborating-with-issues-and-pull-requests/about-pull-requests#draft-pull-requests)”, if you are not yet done writing.
+              **OR**
   * open a "Pull Request", if you are happy with your contribution.
 Anyone can [comment on your (draft) Pull Request](https://docs.github.com/en/github/collaborating-with-issues-and-pull-requests/commenting-on-a-pull-request) and you can reply.
 7. If you had changed your mind about something in your Pull Request (PR), when the PR is not yet closed, or if the editor tells you to edit your PR during the review process, you have to:


### PR DESCRIPTION
1. Edited options for Github issues in the "Announce and discuss your proposal through GitHub issues” section
2. Corrected typos
3. Changed the hyperlink of "create a new issue" in point3 to "preview here"
4. Rewrote the text for points 1, 2 and 6 in the "Content writing" section
5. Changed the hyperlink of  "writing and formatting in GitHub" in point3 to "preview here"

 Closes #93