### PR TITLE
2 tags filtering support + only H2 in toc

### DIFF
--- a/_data/sidebars/main.yml
+++ b/_data/sidebars/main.yml
@@ -22,6 +22,10 @@ entries:
       url: /marine_metagenomics_usecase.html
     - title: Human Data
       url: /humandata_usecase.html
+    - title: Biomolecular simulation data
+      url: /biomolecular_simulation_data.html
+    - title: Intrinsically disordered proteins
+      url: /intrinsically_disordered_proteins.html
   - title: Your problem
     folderitems:
     - title: Storage

--- a/_includes/inline_image.html
+++ b/_includes/inline_image.html
@@ -1,1 +1,0 @@
-<img class="inline" src="images/{{include.file}}" alt="{{include.alt}}" />

--- a/_includes/toc.html
+++ b/_includes/toc.html
@@ -4,7 +4,7 @@
 $( document ).ready(function() {
   // Handler for .ready() called.
 
-$('#toc').toc({ minimumHeaders: 0, listType: 'ul', showSpeed: 0, headers: 'h2,h3,h4' });
+$('#toc').toc({ minimumHeaders: 2, listType: 'ul', showSpeed: 0, headers: 'h2' });
 
 /* this offset helps account for the space taken up by the floating toolbar. */
 $('#toc').on('click', 'a', function() {

--- a/_includes/toollist.html
+++ b/_includes/toollist.html
@@ -1,6 +1,12 @@
-{% assign tools = site.data.tool_and_resource_list %}
-{% assign allowedtags = site.data.tags %}
-{% assign filter_tags = include.tag | split: ", "%}
+{%- assign tools = site.data.tool_and_resource_list -%}
+{%- assign allowedtags = site.data.tags -%}
+{%- assign main_tags = tools.Tools -%}
+{%- if include.tag -%}
+{%- assign main_tags = tools.Tools | where_exp:"tool", "tool.tags contains include.tag" -%}
+{%- endif -%}
+{%- if include.tag2 -%}
+{%- assign main_tags = main_tags | where_exp:"tool", "tool.tags contains include.tag2" -%}
+{%- endif -%}
 <table class="tooltable display">
     <thead>
         <tr>
@@ -11,9 +17,7 @@
         </tr>
     </thead>
     <tbody>
-        {%- for tool in tools.Tools %}
-        {%- for filter_tag in filter_tags%}
-        {%- if tool.tags contains filter_tag or filter_tag == "print_all" %}
+        {%- for tool in main_tags %}
         <tr>
             {% if tool.link %}
             <td><a class="no_icon" href="{{tool.link}}">{{tool.name}}</a></td>
@@ -38,8 +42,6 @@
             {% endif %}
             </td> 
         </tr>
-        {% endif %}
-        {%- endfor %}
         {%- endfor %}
     </tbody>
 </table>

--- a/_includes/toollist.html
+++ b/_includes/toollist.html
@@ -1,5 +1,6 @@
 {% assign tools = site.data.tool_and_resource_list %}
 {% assign allowedtags = site.data.tags %}
+{% assign filter_tags = include.tag | split: ", "%}
 <table class="tooltable display">
     <thead>
         <tr>
@@ -11,7 +12,8 @@
     </thead>
     <tbody>
         {%- for tool in tools.Tools %}
-        {%- if tool.tags contains include.tag or include.tag == "print_all" %}
+        {%- for filter_tag in filter_tags%}
+        {%- if tool.tags contains filter_tag or filter_tag == "print_all" %}
         <tr>
             {% if tool.link %}
             <td><a class="no_icon" href="{{tool.link}}">{{tool.name}}</a></td>
@@ -37,6 +39,7 @@
             </td> 
         </tr>
         {% endif %}
+        {%- endfor %}
         {%- endfor %}
     </tbody>
 </table>

--- a/css/customstyles.css
+++ b/css/customstyles.css
@@ -378,7 +378,7 @@ ul li::marker {
     color: var(--blue-xx-dark);
 }
 
-.tocc {
+#toc {
     padding: 15px;
     background: var(--light-grey);
     margin: 1.75em 0 2em;

--- a/css/customstyles.css
+++ b/css/customstyles.css
@@ -378,7 +378,7 @@ ul li::marker {
     color: var(--blue-xx-dark);
 }
 
-#toc {
+.tocc {
     padding: 15px;
     background: var(--light-grey);
     margin: 1.75em 0 2em;

--- a/js/toc.js
+++ b/js/toc.js
@@ -11,7 +11,6 @@
       showSpeed: 'slow' // set to 0 to deactivate effect
     },
     settings = $.extend(defaults, options);
-
     var headers = $(settings.headers).filter(function() {
       // get all headers with an ID
       var previousSiblingName = $(this).prev().attr( "name" );
@@ -23,6 +22,8 @@
     if (!headers.length || headers.length < settings.minimumHeaders || !output.length) {
       return;
     }
+    // This line is added to prevent that the styling of the TOC is present when there are less headers than the minimum
+    $('#toc').addClass('tocc');
 
     if (0 === settings.showSpeed) {
       settings.showEffect = 'none';

--- a/js/toc.js
+++ b/js/toc.js
@@ -20,10 +20,10 @@
       return this.id;
     }), output = $(this);
     if (!headers.length || headers.length < settings.minimumHeaders || !output.length) {
+      // This line is added to prevent that the styling of the TOC is present when there are less headers than the minimum
+      document.getElementById("toc").style.display="none";
       return;
     }
-    // This line is added to prevent that the styling of the TOC is present when there are less headers than the minimum
-    $('#toc').addClass('tocc');
 
     if (0 === settings.showSpeed) {
       settings.showEffect = 'none';

--- a/pages/all_tools_and_resources.md
+++ b/pages/all_tools_and_resources.md
@@ -5,4 +5,4 @@ toc: false
 custom-editme: _data/main_tool_and_resource_list.csv
 ---
 
-{% include toollist.html tag="print_all" %}
+{% include toollist.html %}

--- a/pages/contribute/editorial_board_guide.md
+++ b/pages/contribute/editorial_board_guide.md
@@ -226,6 +226,14 @@ Giving:
 
 {% include toollist.html tag="monitoring" %}
 
+Add a second tag for filtering using the 'tag2' attribute:
+
+{% raw %}
+```
+{% include toollist.html tag="human data" tag2="plan" %}
+```
+{% endraw %}
+
 Tools and resources can be added by manipulating the tool_and_resource_list.xlsx file in the `_data` repository.
 More information on how to add a tool or resource can be found [here](tool_resource_update).
 

--- a/pages/contribute/markdown_cheat_sheet.md
+++ b/pages/contribute/markdown_cheat_sheet.md
@@ -334,6 +334,14 @@ Giving:
 
 {% include toollist.html tag="monitoring" %}
 
+Add a second tag for filtering using the 'tag2' attribute:
+
+{% raw %}
+```
+{% include toollist.html tag="human data" tag2="plan" %}
+```
+{% endraw %}
+
 Make sure the tag exists in the `tool_and_resource_list.yml` file + in the `tags.yml`.
 
 Tools and resources can be added by manipulating the main_tool_and_resource_list.csv file in the `_data` repository. For more info about how to add a tool or resource please visit [our guide](tool_resource_update).


### PR DESCRIPTION
- [x] new domains links in sidepanel, will close #141 and close #140 
- [x] tool resource lists can now be filtered with 2 tags by using the tag2 attribute:
  ```
  {% include toollist.html tag="human data" tag2="share"%}
  ```
- [x] Table of contents only shows H2 titles