### PR TITLE
Labels less vibrant

### DIFF
--- a/_includes/toollist.html
+++ b/_includes/toollist.html
@@ -24,9 +24,16 @@
             {% else %}
             <td>{{tool.name}}</td>
             {% endif %}
-            <td>{{tool.description}}{{page.url}}</td>
-            {%- capture tags %}
-        {%- for tag in tool.tags %}{% if page.url == allowedtags[tag]["url"] %}{% assign bg-color = allowedtags[tag]["bg-color"] | default: "#080808" %}{% else %}{% assign color = var(--main-text-color)%}{% endif %}{% assign link = allowedtags[tag]["url"] | default: "#" %}<a class="nohover" href="{{link}}"><span class="label" style="color:{{color}}; background-color:{{bg-color}};">{{tag}}</span></a> {% endfor %}
+            <td>{{tool.description}}</td>
+            {% capture tags %}
+            {% for tag in tool.tags %}
+            {% if include.tag == tag or include.tag2 == tag %}{% assign bg-color = allowedtags[tag]["bg-color"] | default: "#080808" %}{% assign color = "white" %}
+            <span class="label" style="color:{{color}}; background-color:{{bg-color}};">{{tag}}</span>
+            {% else %}
+            {% assign link = allowedtags[tag]["url"] | default: "#" %}
+            <a class="nohover" href="{{link}}"><span class="label default-label">{{tag}}</span></a>
+            {% endif %}
+            {% endfor %}
             {%- endcapture %}
             <td>{{tags}}</td>
             <td style="text-align: center; vertical-align: middle;">

--- a/_includes/toollist.html
+++ b/_includes/toollist.html
@@ -21,32 +21,32 @@
         <tr>
             {% if tool.link %}
             <td><a class="no_icon" href="{{tool.link}}">{{tool.name}}</a></td>
-            {% else %}
+            {%- else %}
             <td>{{tool.name}}</td>
-            {% endif %}
+            {%- endif %}
             <td>{{tool.description}}</td>
-            {% capture tags %}
-            {% for tag in tool.tags %}
-            {% if include.tag == tag or include.tag2 == tag %}{% assign bg-color = allowedtags[tag]["bg-color"] | default: "#080808" %}{% assign color = "white" %}
+            {%- capture tags %}
+            {%- for tag in tool.tags %}
+            {%- if include.tag == tag or include.tag2 == tag %}{% assign bg-color = allowedtags[tag]["bg-color"] | default: "#080808" %}{% assign color = "white" %}
             <span class="label" style="color:{{color}}; background-color:{{bg-color}};">{{tag}}</span>
-            {% else %}
-            {% assign link = allowedtags[tag]["url"] | default: "#" %}
+            {%- else %}
+            {%- assign link = allowedtags[tag]["url"] | default: "#" %}
             <a class="nohover" href="{{link}}"><span class="label default-label">{{tag}}</span></a>
-            {% endif %}
-            {% endfor %}
+            {%- endif %}
+            {%- endfor %}
             {%- endcapture %}
             <td>{{tags}}</td>
             <td style="text-align: center; vertical-align: middle;">
-            {% if tool.registry.biotools %}
+            {%- if tool.registry.biotools %}
             <a data-toggle="tooltip"
                 data-original-title="Bio.tools ID: {{tool.registry.biotools}}" href="https://bio.tools/{{tool.registry.biotools}}"
                 class="no_icon"><img style="background-color: orange;" class="registry_logo" src="images/bio.tools.svg" alt="bio.tools logo"/></a>
-            {% endif %}
-            {% if tool.registry.fairsharing %}
+            {%- endif %}
+            {%- if tool.registry.fairsharing %}
             <a data-toggle="tooltip"
                 data-original-title="FAIRsharing ID: {{tool.registry.fairsharing}}" href="https://fairsharing.org/FAIRsharing.{{tool.registry.fairsharing}}"
                 class="no_icon"><img style="background-color: #ECF0F1;" class="registry_logo" src="images/FAIRsharing-small.svg" alt="FAIRsharing logo"/></a>
-            {% endif %}
+            {%- endif %}
             </td> 
         </tr>
         {%- endfor %}

--- a/_includes/toollist.html
+++ b/_includes/toollist.html
@@ -24,9 +24,9 @@
             {% else %}
             <td>{{tool.name}}</td>
             {% endif %}
-            <td>{{tool.description}}</td>
+            <td>{{tool.description}}{{page.url}}</td>
             {%- capture tags %}
-        {%- for tag in tool.tags %}{% assign color = allowedtags[tag]["bg-color"] | default: "#080808" %}{% assign link = allowedtags[tag]["url"] | default: "#" %}<a class="nohover" href="{{link}}"><span class="label" style="background-color:{{color}};">{{tag}}</span></a> {% endfor %}
+        {%- for tag in tool.tags %}{% if page.url == allowedtags[tag]["url"] %}{% assign bg-color = allowedtags[tag]["bg-color"] | default: "#080808" %}{% else %}{% assign color = var(--main-text-color)%}{% endif %}{% assign link = allowedtags[tag]["url"] | default: "#" %}<a class="nohover" href="{{link}}"><span class="label" style="color:{{color}}; background-color:{{bg-color}};">{{tag}}</span></a> {% endfor %}
             {%- endcapture %}
             <td>{{tags}}</td>
             <td style="text-align: center; vertical-align: middle;">

--- a/css/customstyles.css
+++ b/css/customstyles.css
@@ -264,7 +264,7 @@ th {
 }
 
 table>thead>tr>th, table>tbody>tr>th, table>tfoot>tr>th, table>thead>tr>td, table>tbody>tr>td, table>tfoot>tr>td {
-    padding: 8px;
+    padding: 8px 8px 8px 0px;
     line-height: 1.42857143;
     vertical-align: top;
     border-top: 1px solid var(--light-grey);

--- a/css/customstyles.css
+++ b/css/customstyles.css
@@ -65,6 +65,17 @@ h3+h4 {
 * Spacer classes (not in Bootstrap 3)
 */
 
+.default-label {
+    font-weight: inherit;
+    background-color: var(--light-grey);
+    color: var(--main-text-color)
+}
+
+.default-label:hover {
+    color:var(--white-text);
+    background-color: var(--subtle-text);
+}
+
 .mt-0 {
     margin-top: 0;
 }

--- a/pages/your_domain/biomolecular_simulation_data.md
+++ b/pages/your_domain/biomolecular_simulation_data.md
@@ -1,7 +1,6 @@
 ---
 title: "Biomolecular simulation data"
 keywords: molecular dynamics, docking, virtual screening
-search: exclude
 ---
 ## General scope
 Here we show what are (bio)simulation data, how we can store them, how it can be reused for new, unexpected projects, and how they can be transformed to make them FAIR (findable, accessible, interoperable and reusable). However, we should stress that these guidelines are not carved to stone and the biomolecular simulation community still needs to address challenges to FAIRify its data.

--- a/pages/your_domain/humandata_usecase.md
+++ b/pages/your_domain/humandata_usecase.md
@@ -1,6 +1,5 @@
 ---
 title: Human Data
-keywords: optional
 contributors: [Niclas Jareborg, Nirupama Benis, Ana Portugal Melo, Pinar Alper]
 ---
 

--- a/pages/your_domain/intrinsically_disordered_proteins.md
+++ b/pages/your_domain/intrinsically_disordered_proteins.md
@@ -1,7 +1,5 @@
 ---
 title: "Intrinsically Disordered Proteins community"
-keywords: optional
-search: exclude
 ---
 
 


### PR DESCRIPTION
I made the labels grey and only the one that is "selected" in its respective color. They also have a hover over effect now. 
+ changed some metadata mistakes.

All tools:
![Screenshot from 2020-11-12 19-31-57](https://user-images.githubusercontent.com/44875756/98981446-3b5b0700-251e-11eb-9f77-5b82e34bdfab.png)

share filtered list:

![Screenshot from 2020-11-12 19-32-13](https://user-images.githubusercontent.com/44875756/98981498-4e6dd700-251e-11eb-8180-f9dc205ddf7b.png)
