### PR TITLE
Automatic TeSS linking + tool table update

### DIFF
--- a/.github/workflows/list_conversion.yml
+++ b/.github/workflows/list_conversion.yml
@@ -3,6 +3,8 @@ name: Converting the tool and resource table
 on:
   push:
     branches: [ master ]
+  schedule:
+    - cron:  '0 5 * * 1'
 jobs:
   build:
     runs-on: ubuntu-latest
@@ -21,7 +23,7 @@ jobs:
           pip install pyyaml
       - name: Run tool table 2 yaml
         run: |
-          python var/tool_table2yaml.py
+          python var/tool_table2yaml.py --tess
       - name: Show differences
         run: 'git diff --stat'
       - name: Create Pull Request

--- a/.github/workflows/list_conversion.yml
+++ b/.github/workflows/list_conversion.yml
@@ -20,7 +20,7 @@ jobs:
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
-          pip install pyyaml
+          pip install pyyaml requests
       - name: Run tool table 2 yaml
         run: |
           python var/tool_table2yaml.py --tess

--- a/.github/workflows/list_validation.yml
+++ b/.github/workflows/list_validation.yml
@@ -18,7 +18,7 @@ jobs:
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
-          pip install pyyaml
+          pip install pyyaml requests
       - name: Run tool table 2 yaml
         run: |
           python var/tool_table2yaml.py

--- a/_data/sidebars/contribute.yml
+++ b/_data/sidebars/contribute.yml
@@ -9,15 +9,15 @@ entries:
           url: /github_way.html
         - title: Google doc way
           url: /google_doc_way.html
+        - title: Git way (advanced)
+          url: /working_with_git.html
         - title: Add new tool or resource
           url: /tool_resource_update.html
-        - title: Style guide
-          url: /style_guide.html
-        - title: Copyright guidelines
-          url: /copyright.html
-        - title: Markdown cheat sheet
-          url: /markdown_cheat_sheet.html
-        - title: Editorial board guide
-          url: /editorial_board_guide.html
-        - title: Working with Git
-          url: /working_with_git.html
+      - title: Style guide
+        url: /style_guide.html
+      - title: Copyright guidelines
+        url: /copyright.html
+      - title: Markdown cheat sheet
+        url: /markdown_cheat_sheet.html
+      - title: Editorial board guide
+        url: /editorial_board_guide.html

--- a/_data/sidebars/contribute.yml
+++ b/_data/sidebars/contribute.yml
@@ -11,8 +11,8 @@ entries:
           url: /google_doc_way.html
         - title: Git way (advanced)
           url: /working_with_git.html
-        - title: Add new tool or resource
-          url: /tool_resource_update.html
+      - title: Add new tool or resource
+        url: /tool_resource_update.html
       - title: Style guide
         url: /style_guide.html
       - title: Copyright guidelines

--- a/_data/tool_and_resource_list.yml
+++ b/_data/tool_and_resource_list.yml
@@ -92,6 +92,7 @@ Tools:
   name: fairsharing
   registry:
     fairsharing: 2abjs5
+    tess: fairsharing
   tags:
   - plan
   - collect
@@ -109,11 +110,13 @@ Tools:
   name: GitHub
   registry:
     fairsharing: biodbcore-001160
+    tess: GitHub
 - description: Protein Homology/analogY Recognition Engine
   link: http://www.sbg.bio.ic.ac.uk/~phyre2
   name: Phyre2
   registry:
     biotools: phyre
+    tess: Phyre2
   tags:
   - process
   - analyse
@@ -122,6 +125,7 @@ Tools:
   name: MIAPPE
   registry:
     fairsharing: nd9ce9
+    tess: MIAPPE
   tags:
   - standard
   - re-use
@@ -150,6 +154,7 @@ Tools:
   name: SEEK
   registry:
     biotools: seek
+    tess: SEEK
   tags:
   - collect
   - process
@@ -171,6 +176,7 @@ Tools:
   name: ArrayExpress
   registry:
     fairsharing: 6k0kwd
+    tess: ArrayExpress
   tags:
   - share
   - re-use
@@ -179,6 +185,7 @@ Tools:
   name: BioModels
   registry:
     fairsharing: paz6mh
+    tess: BioModels
   tags:
   - share
   - re-use
@@ -188,6 +195,7 @@ Tools:
   name: BioSamples
   registry:
     fairsharing: ewjdq6
+    tess: BioSamples
   tags:
   - share
   - re-use
@@ -217,6 +225,7 @@ Tools:
   name: EVA
   registry:
     fairsharing: 6824pv
+    tess: EVA
   tags:
   - share
   - re-use
@@ -226,6 +235,7 @@ Tools:
   name: IntAct
   registry:
     fairsharing: d05nwx
+    tess: IntAct
   tags:
   - share
   - re-use
@@ -235,6 +245,7 @@ Tools:
   name: Metabolights
   registry:
     fairsharing: kkdpxe
+    tess: Metabolights
   tags:
   - share
   - re-use
@@ -245,6 +256,7 @@ Tools:
   name: PRIDE
   registry:
     fairsharing: e1byny
+    tess: PRIDE
   tags:
   - share
   - re-use
@@ -255,6 +267,7 @@ Tools:
   name: PDBE
   registry:
     fairsharing: 26ek1v
+    tess: PDBE
   tags:
   - share
   - re-use
@@ -264,6 +277,7 @@ Tools:
   name: EGA
   registry:
     fairsharing: mya1ff
+    tess: EGA
   tags:
   - share
   - re-use
@@ -276,6 +290,7 @@ Tools:
   name: ENA
   registry:
     fairsharing: dj8nt8
+    tess: ENA
   tags:
   - share
   - re-use
@@ -309,6 +324,7 @@ Tools:
   name: Crop Ontology
   registry:
     fairsharing: bsg-s002695
+    tess: Crop Ontology
   tags:
   - standard
   - re-use
@@ -346,6 +362,7 @@ Tools:
   name: Data Use Ontology
   registry:
     fairsharing: 5dnjs2
+    tess: Data Use Ontology
   tags:
   - human data
   - privacy
@@ -433,6 +450,7 @@ Tools:
   name: BRENDA
   registry:
     fairsharing: etp533
+    tess: BRENDA
   tags:
   - human data
   - re-use
@@ -450,35 +468,41 @@ Tools:
   name: CATH
   registry:
     fairsharing: xgcyyn
+    tess: CATH
 - description: Dictionary of molecular entities focused on 'small' chemical compounds
   link: https://www.ebi.ac.uk/chebi/
   name: ChEBI
   registry:
     fairsharing: 62qk8w
+    tess: ChEBI
 - description: Database of bioactive drug-like small molecules, it contains 2-D structures,
     calculated properties and abstracted bioactivities.
   link: https://www.ebi.ac.uk/chembl/
   name: ChEMBL
   registry:
     fairsharing: m3jtpg
+    tess: ChEMBL
 - description: Genome browser for vertebrate genomes that supports research in comparative
     genomics, evolution, sequence variation and transcriptional regulation.
   link: http://www.ensembl.org/index.html
   name: Ensembl
   registry:
     fairsharing: fx0mw7
+    tess: Ensembl
 - description: Comparative analysis, data mining and visualisation for the genomes
     of non-vertebrate species
   link: http://ensemblgenomes.org/
   name: Ensembl Genomes
   registry:
     fairsharing: 923a0p
+    tess: Ensembl Genomes
 - description: Europe PMC is a repository, providing access to worldwide life sciences
     articles, books, patents and clinical guidelines.
   link: https://europepmc.org/
   name: Europe PMC
   registry:
     fairsharing: cmw6mm
+    tess: Europe PMC
 - description: The Human Protein Atlas contains information for a large majority of
     all human protein-coding genes regarding the expression and localization of the
     corresponding proteins based on both RNA and protein data.
@@ -486,6 +510,7 @@ Tools:
   name: Human Protein Atlas
   registry:
     fairsharing: j0t0pe
+    tess: Human Protein Atlas
 - description: List of metadata standards
   link: https://www.dcc.ac.uk/guidance/standards/metadata/list
   name: Data Curation Centre Metadata list
@@ -508,6 +533,7 @@ Tools:
   name: InterPro
   registry:
     fairsharing: pda11d
+    tess: InterPro
   tags:
   - re-use
 - description: The Orphadata platform provides the scientific community with comprehensive,
@@ -526,6 +552,7 @@ Tools:
   name: Silva
   registry:
     fairsharing: 5vtYGG
+    tess: Silva
   tags:
   - re-use
 - description: Known and predicted protein-protein interactions.
@@ -533,6 +560,7 @@ Tools:
   name: STRING
   registry:
     fairsharing: 9b7wvk
+    tess: STRING
   tags:
   - re-use
 - description: Comprehensive resource for protein sequence and annotation data
@@ -540,5 +568,6 @@ Tools:
   name: UniProt
   registry:
     fairsharing: s1ne3g
+    tess: UniProt
   tags:
   - re-use

--- a/_includes/toollist.html
+++ b/_includes/toollist.html
@@ -47,6 +47,11 @@
                 data-original-title="FAIRsharing ID: {{tool.registry.fairsharing}}" href="https://fairsharing.org/FAIRsharing.{{tool.registry.fairsharing}}"
                 class="no_icon"><img style="background-color: #ECF0F1;" class="registry_logo" src="images/FAIRsharing-small.svg" alt="FAIRsharing logo"/></a>
             {%- endif %}
+            {%- if tool.registry.tess %}
+            <a data-toggle="tooltip"
+                data-original-title="FAIRsharing ID: {{tool.registry.tess}}" href="https://tess.elixir-europe.org/search?q={{tool.registry.tess}}" 
+                class="no_icon"><img style="background-color: #f47d20;" class="registry_logo" src="images/tess_logo.svg" alt="TeSS logo"/></a>
+            {%- endif %}
             </td> 
         </tr>
         {%- endfor %}

--- a/_includes/toollist.html
+++ b/_includes/toollist.html
@@ -49,7 +49,7 @@
             {%- endif %}
             {%- if tool.registry.tess %}
             <a data-toggle="tooltip"
-                data-original-title="FAIRsharing ID: {{tool.registry.tess}}" href="https://tess.elixir-europe.org/search?q={{tool.registry.tess}}" 
+                data-original-title="TeSS: {{tool.registry.tess}}" href="https://tess.elixir-europe.org/search?q={{tool.registry.tess}}" 
                 class="no_icon"><img style="background-color: #f47d20;" class="registry_logo" src="images/tess_logo.svg" alt="TeSS logo"/></a>
             {%- endif %}
             </td> 

--- a/pages/all_tools_and_resources.md
+++ b/pages/all_tools_and_resources.md
@@ -5,7 +5,7 @@ toc: false
 custom-editme: _data/main_tool_and_resource_list.csv
 ---
 
-This is the main tool and resource list of our website. This is a curated list which means that not all tools or resources that exist for a certain topic are listed here. This is mainly because we do not intend to be a registry. In most cases this will only be the ones that are mentioned in pages. Most pages will show a filtered list of this main table at the end of the page. Tools and resources are manually linked to bio.tools and FAIRsharing. The link with TeSS is automatically made and weekly updated. If you see a missing link with one of the registries (bio.tools, FAIRsharing and TeSS) or a mistake, please open an [issue](https://github.com/elixir-europe/rdm-toolkit/issues) or check our [how to add a tool or resource guide](tool_resource_update).
+This is the main tool and resource list of our website. This is a curated list which means that not all tools or resources that exist for a certain topic are listed here. This is mainly because we do not intend to be a registry. In most cases you will only find back the tools or resources that are mentioned in the different pages. Most pages will show a filtered list of this main table at the end of the page. Tools and resources are manually linked to [Bio.tools](https://bio.tools) and [FAIRsharing.org](https://fairsharing.org/). The link with [TeSS](https://tess.elixir-europe.org/) is automatically made and weekly updated. If you see a missing link with one of the registries or a mistake, please open an [issue](https://github.com/elixir-europe/rdm-toolkit/issues) or check our [how to add a tool or resource guide](tool_resource_update).
 
 
 {% include toollist.html %}

--- a/pages/all_tools_and_resources.md
+++ b/pages/all_tools_and_resources.md
@@ -5,4 +5,7 @@ toc: false
 custom-editme: _data/main_tool_and_resource_list.csv
 ---
 
+This is the main tool and resource list of our website. This is a curated list which means that not all tools or resources that exist for a certain topic are listed here. This is mainly because we do not intend to be a registry. In most cases this will only be the ones that are mentioned in pages. Most pages will show a filtered list of this main table at the end of the page. Tools and resources are manually linked to bio.tools and FAIRsharing. The link with TeSS is automatically made and weekly updated. If you see a missing link with one of the registries (bio.tools, FAIRsharing and TeSS) or a mistake, please open an [issue](https://github.com/elixir-europe/rdm-toolkit/issues) or check our [how to add a tool or resource guide](tool_resource_update).
+
+
 {% include toollist.html %}

--- a/pages/all_tools_and_resources.md
+++ b/pages/all_tools_and_resources.md
@@ -5,7 +5,7 @@ toc: false
 custom-editme: _data/main_tool_and_resource_list.csv
 ---
 
-This is the main tool and resource list of our website. This is a curated list which means that not all tools or resources that exist for a certain topic are listed here. This is mainly because we do not intend to be a registry. In most cases you will only find back the tools or resources that are mentioned in the different pages. Most pages will show a filtered list of this main table at the end of the page. Tools and resources are manually linked to [Bio.tools](https://bio.tools) and [FAIRsharing.org](https://fairsharing.org/). The link with [TeSS](https://tess.elixir-europe.org/) is automatically made and weekly updated. If you see a missing link with one of the registries or a mistake, please open an [issue](https://github.com/elixir-europe/rdm-toolkit/issues) or check our [how to add a tool or resource guide](tool_resource_update).
+This is the main tool and resource list of our website. This is a curated list which means that not all tools or resources that exist for a certain topic are listed here. This is mainly because we do not intend to be a registry. In most cases you will only find back the tools or resources that are mentioned in the different pages. Most pages will show a filtered list of this main table at the end of the page. If you see a missing link with one of the registries or a mistake, please open an [issue](https://github.com/elixir-europe/rdm-toolkit/issues) or check our [how to add a tool or resource guide](tool_resource_update).
 
 
 {% include toollist.html %}

--- a/pages/contribute/tool_resource_update.md
+++ b/pages/contribute/tool_resource_update.md
@@ -6,7 +6,9 @@ summary: How to add a tool or resource to RDM Toolkit
 
 ## Way of working
 
-The tools or resources you will find on pages are a filtered set from a bigger list. This filtering is done using tags. The general tool/resource list is based on the [csv file](https://github.com/elixir-europe/rdm-toolkit/blob/master/_data/main_tool_and_resource_list.csv) in the `_data` directory of the RDM Toolkit repository. If changes to this file are pushed to Github, a Github Bot will generate a Pull Request (PR) with the changes of the csv file applied to the main data file of the website (a yaml file).
+The tools or resources you will find on pages are a filtered set from a [bigger list](all_tools_and_resources). This filtering is done using tags. The general tool/resource list is based on the [csv file](https://github.com/elixir-europe/rdm-toolkit/blob/master/_data/main_tool_and_resource_list.csv) in the `_data` directory of the RDM Toolkit repository. If changes to this file are pushed to Github, a Github Bot will generate a Pull Request (PR) with the changes of the csv file applied to the main data file of the website (a yaml file).
+
+{% include important.html content="The link with TeSS is automatically done using GitHub actions and is weekly updated. These automatic links are not seen in the table. The search query to TeSS for a tool or resource can be overwritten in the registry column of the main csv tool table." %}
 
 ## The main table
 
@@ -15,7 +17,7 @@ The table consists of 5 columns:
 - **name**: the name of the tool or resource
 - **link**: URL to the main page of the tool or resource, make sure to let the URL start with https://
 - **description**: A short description of the tool or resource. Try to not use the characters `"` or `'` 
-- **registry**: 2 registries are supported: [Bio.tools](https://bio.tools) and [FAIRsharing.org](https://fairsharing.org/). The keywords you can use respectivly are: biotools and fairsharing specifying the id with a colon). List multiple registries using a comma `, ` between the keywords. 
+- **registry**: 3 registries are supported: [Bio.tools](https://bio.tools), [FAIRsharing.org](https://fairsharing.org/) and [TeSS](https://tess.elixir-europe.org/). The keywords you can use respectively are: biotools, fairsharing and tess, specifying the id or query with a colon). List multiple registries using a comma `, ` between the keywords to seperate the key:value pairs. 
 - **tags**: This is used to tag the tools so it is listed on the correct page. Make sure your tag is listed in the curated list of tags ( The `tags.yaml` file [here](https://github.com/elixir-europe/rdm-toolkit/blob/master/_data/tags.yml) ). List multiple tags by using a comma `, ` between them.
 
 | name   	| link                                     	| description                                                                                         	| registry           	| tags             	|

--- a/pages/contribute/tool_resource_update.md
+++ b/pages/contribute/tool_resource_update.md
@@ -6,7 +6,7 @@ summary: How to add a tool or resource to RDM Toolkit
 
 ## Way of working
 
-The tools or resources you will find on pages are a filtered set from a [bigger list](all_tools_and_resources). This filtering is done using tags. The general tool/resource list is based on the [csv file](https://github.com/elixir-europe/rdm-toolkit/blob/master/_data/main_tool_and_resource_list.csv) in the `_data` directory of the RDM Toolkit repository. If changes to this file are pushed to Github, a Github Bot will generate a Pull Request (PR) with the changes of the csv file applied to the main data file of the website (a yaml file).
+The tools or resources you will find on pages are a filtered set from a [bigger list](all_tools_and_resources). This filtering is done using tags. The general tool/resource list is based on the [csv file](https://github.com/elixir-europe/rdm-toolkit/blob/master/_data/main_tool_and_resource_list.csv) in the `_data` directory of the RDM Toolkit repository. Tools and resources are manually linked to [Bio.tools](https://bio.tools) and [FAIRsharing.org](https://fairsharing.org/). The link with [TeSS](https://tess.elixir-europe.org/) is automatically made and weekly updated. If changes to this file are pushed to Github, a Github Bot will generate a Pull Request (PR) with the changes of the csv file applied to the main data file of the website (a yaml file).
 
 {% include important.html content="The link with TeSS is automatically done using GitHub actions and is weekly updated. These automatic links are not seen in the table. The search query to TeSS for a tool or resource can be overwritten in the registry column of the main csv tool table." %}
 

--- a/var/tool_table2yaml.py
+++ b/var/tool_table2yaml.py
@@ -64,7 +64,7 @@ with open(table_path, 'r') as read_obj:
                                 output[reg] = identifier
                             else:
                                 sys.exit(f'The table contains the registry "{reg}" in row {row_index} which is not allowed.\n' + f"Allowed registries are {', '.join(allowed_registries)}.\n")
-                        if sys.argv[1] == "--tess" and material_available(tool_name) and not "tess" in output:
+                        if sys.argv and sys.argv[1] == "--tess" and material_available(tool_name) and not "tess" in output:
                             output["tess"] = tool_name
                     else:
                         output = unicodedata.normalize("NFKD", cell).strip() # Return the normal form for the Unicode string

--- a/var/tool_table2yaml.py
+++ b/var/tool_table2yaml.py
@@ -64,7 +64,7 @@ with open(table_path, 'r') as read_obj:
                                 output[reg] = identifier
                             else:
                                 sys.exit(f'The table contains the registry "{reg}" in row {row_index} which is not allowed.\n' + f"Allowed registries are {', '.join(allowed_registries)}.\n")
-                        if sys.argv and sys.argv[1] == "--tess" and material_available(tool_name) and not "tess" in output:
+                        if len(sys.argv) > 1 and sys.argv[1] == "--tess" and material_available(tool_name) and not "tess" in output:
                             output["tess"] = tool_name
                     else:
                         output = unicodedata.normalize("NFKD", cell).strip() # Return the normal form for the Unicode string

--- a/var/tool_table2yaml.py
+++ b/var/tool_table2yaml.py
@@ -7,7 +7,8 @@ import requests
 from requests.adapters import HTTPAdapter
 from urllib3.util.retry import Retry
 
-def tess_client (url):
+
+def tess_client(url):
     """API object fetcher"""
     session = requests.Session()
     retry = Retry(connect=3, backoff_factor=15)
@@ -21,11 +22,13 @@ def tess_client (url):
         return r.json()
 
 
-def material_available (query):
-    json_output = tess_client(f"https://tess.elixir-europe.org/materials?q={query}&page_number=1&page_size=30")
+def material_available(query):
+    json_output = tess_client(
+        f"https://tess.elixir-europe.org/materials?q={query}&page_number=1&page_size=30")
 
     if len(json_output) > 0:
         return True
+
 
 table_path = "_data/main_tool_and_resource_list.csv"
 output_path = "_data/tool_and_resource_list.yml"
@@ -50,24 +53,27 @@ with open(table_path, 'r') as read_obj:
             tool = {}
             tool_name = row[0]
             for col_index, cell in enumerate(row):
-                if cell: # Only include keys if there are values
-                    if  header[col_index] == 'tags':
+                if cell:  # Only include keys if there are values
+                    if header[col_index] == 'tags':
                         output = re.split(', |,', cell)
                         for tag in output:
                             if tag not in allowed_tags:
-                                sys.exit(f'The table contains the tag "{tag}" in row {row_index} which is not allowed.\n-> Check out the tool_tags.yaml file in the _data directory to find out the allowed tags.')
+                                sys.exit(
+                                    f'The table contains the tag "{tag}" in row {row_index} which is not allowed.\n-> Check out the tool_tags.yaml file in the _data directory to find out the allowed tags.')
                     elif header[col_index] == 'registry':
-                        output={}
+                        output = {}
                         for registry in re.split(', |,', cell):
                             reg, identifier = re.split(':|: ', registry)
                             if reg in allowed_registries:
                                 output[reg] = identifier
                             else:
-                                sys.exit(f'The table contains the registry "{reg}" in row {row_index} which is not allowed.\n' + f"Allowed registries are {', '.join(allowed_registries)}.\n")
+                                sys.exit(
+                                    f'The table contains the registry "{reg}" in row {row_index} which is not allowed.\n' + f"Allowed registries are {', '.join(allowed_registries)}.\n")
                         if len(sys.argv) > 1 and sys.argv[1] == "--tess" and material_available(tool_name) and not "tess" in output:
                             output["tess"] = tool_name
                     else:
-                        output = unicodedata.normalize("NFKD", cell).strip() # Return the normal form for the Unicode string
+                        # Return the normal form for the Unicode string
+                        output = unicodedata.normalize("NFKD", cell).strip()
                     tool[header[col_index]] = output
             main_dict[main_dict_key].append(tool)
             print(f"{row_index}. {tool['name']} is parsed.")

--- a/var/tool_table2yaml.py
+++ b/var/tool_table2yaml.py
@@ -3,12 +3,35 @@ from csv import reader
 import yaml
 import re
 import unicodedata
+import requests
+from requests.adapters import HTTPAdapter
+from urllib3.util.retry import Retry
+
+def tess_client (url):
+    """API object fetcher"""
+    session = requests.Session()
+    retry = Retry(connect=3, backoff_factor=15)
+    adapter = HTTPAdapter(max_retries=retry)
+    session.mount('http://', adapter)
+    session.mount('https://', adapter)
+    r = session.get(url)
+    if r.status_code != requests.codes.ok:
+        raise RuntimeError("Non-200 status code")
+    else:
+        return r.json()
+
+
+def material_available (query):
+    json_output = tess_client(f"https://tess.elixir-europe.org/materials?q={query}&page_number=1&page_size=30")
+
+    if len(json_output) > 0:
+        return True
 
 table_path = "_data/main_tool_and_resource_list.csv"
 output_path = "_data/tool_and_resource_list.yml"
 main_dict_key = "Tools"
 allowed_tags_yaml = "_data/tags.yml"
-allowed_registries = ['biotools', 'fairsharing']
+allowed_registries = ['biotools', 'fairsharing', 'tess']
 
 print(f"----> Converting table {table_path} to {output_path} started.")
 
@@ -25,6 +48,7 @@ with open(table_path, 'r') as read_obj:
         # Looping over rows and adding its contents to the main dict
         for row_index, row in enumerate(csv_reader):
             tool = {}
+            tool_name = row[0]
             for col_index, cell in enumerate(row):
                 if cell: # Only include keys if there are values
                     if  header[col_index] == 'tags':
@@ -35,11 +59,13 @@ with open(table_path, 'r') as read_obj:
                     elif header[col_index] == 'registry':
                         output={}
                         for registry in re.split(', |,', cell):
-                            reg, identifier = re.split(':', registry)
+                            reg, identifier = re.split(':|: ', registry)
                             if reg in allowed_registries:
                                 output[reg] = identifier
                             else:
-                                sys.exit(f'The table contains the registry "{reg}" in row {row_index} which is not allowed.\n')
+                                sys.exit(f'The table contains the registry "{reg}" in row {row_index} which is not allowed.\n' + f"Allowed registries are {', '.join(allowed_registries)}.\n")
+                        if sys.argv[1] == "--tess" and material_available(tool_name) and not "tess" in output:
+                            output["tess"] = tool_name
                     else:
                         output = unicodedata.normalize("NFKD", cell).strip() # Return the normal form for the Unicode string
                     tool[header[col_index]] = output


### PR DESCRIPTION
- [x] Add support for tess resource to toollist (closes #181 and closes #228 )

![Screenshot from 2020-11-26 18-35-03](https://user-images.githubusercontent.com/44875756/100379940-1f735d00-3016-11eb-840e-d65f8b8acaff.png)

- [x] Adapt conversion script to check for TeSS link
- [x] Adapting github action to check on a weekly basis for changes
- [x] Adapt documentation
- [x] Description of the main tool table ( closes #203 )
- [x] Contribute levels navigation update
![Screenshot from 2020-11-26 18-34-01](https://user-images.githubusercontent.com/44875756/100379881-fb178080-3015-11eb-873a-9c2111f4922f.png)

I am aware that the logo of bio.tools and TeSS do not differ enough. Do we cut out the biotools and TeSS part out of the elixir logo?
- [ ] Better distinguishable logos